### PR TITLE
Add caching support for IdentityProviderStorageProvider.getForLogin operations

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/IdentityProviderStorageProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/IdentityProviderStorageProvider.java
@@ -251,6 +251,7 @@ public interface IdentityProviderStorageProvider extends Provider {
 
         public static Predicate<IdentityProviderModel> getLoginPredicate() {
             return ((Predicate<IdentityProviderModel>) Objects::nonNull)
+                    .and(idp -> idp.getOrganizationId() == null || Boolean.parseBoolean(idp.getConfig().get(OrganizationModel.BROKER_PUBLIC)))
                     .and(Stream.of(values()).map(LoginFilter::getFilter).reduce(Predicate::and).get());
         }
     }

--- a/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareIdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareIdentityProviderBean.java
@@ -72,12 +72,12 @@ public class OrganizationAwareIdentityProviderBean extends IdentityProviderBean 
             }
             // we don't have a specific organization - fetch public enabled IDPs linked to any org.
             return session.identityProviders().getForLogin(ORG_ONLY, null)
-                    .filter(idp -> !Objects.equals(existingIDP, idp.getAlias()))
+                    .filter(idp -> idp.isEnabled() && !Objects.equals(existingIDP, idp.getAlias())) // re-check isEnabled as idp might have been wrapped.
                     .map(idp -> createIdentityProvider(this.realm, this.baseURI, idp))
                     .sorted(IDP_COMPARATOR_INSTANCE).toList();
         }
         return session.identityProviders().getForLogin(ALL, this.organization != null ? this.organization.getId() : null)
-                .filter(idp -> !Objects.equals(existingIDP, idp.getAlias()))
+                .filter(idp -> idp.isEnabled() && !Objects.equals(existingIDP, idp.getAlias())) // re-check isEnabled as idp might have been wrapped.
                 .map(idp -> createIdentityProvider(this.realm, this.baseURI, idp))
                 .sorted(IDP_COMPARATOR_INSTANCE).toList();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/cache/OrganizationCacheTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/cache/OrganizationCacheTest.java
@@ -20,6 +20,7 @@ package org.keycloak.testsuite.organization.cache;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.keycloak.models.cache.infinispan.idp.InfinispanIdentityProviderStorageProvider.cacheKeyForLogin;
 import static org.keycloak.models.cache.infinispan.idp.InfinispanIdentityProviderStorageProvider.cacheKeyOrgId;
 import static org.keycloak.models.cache.infinispan.organization.InfinispanOrganizationProvider.cacheKeyOrgMemberCount;
 
@@ -32,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.models.IdentityProviderStorageProvider;
+import org.keycloak.models.IdentityProviderStorageProvider.FetchMode;
 import org.keycloak.models.OrganizationDomainModel;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
@@ -361,6 +363,174 @@ public class OrganizationCacheTest extends AbstractOrganizationTest {
             String cachedKeyB = cacheKeyOrgId(realm, orgbId);
             identityProviderListQuery = realmCache.getCache().get(cachedKeyB, IdentityProviderListQuery.class);
             assertNull(identityProviderListQuery);
+        });
+    }
+
+    @Test
+    public void testCacheIDPForLogin() {
+        // create 20 providers, and associate 10 of them with an organization.
+        for (int i = 0; i < 20; i++) {
+            IdentityProviderRepresentation idpRep = new IdentityProviderRepresentation();
+            idpRep.setAlias("idp-alias-" + i);
+            idpRep.setEnabled((i % 2) == 0); // half of the IDPs will be disabled and won't qualify for login.
+            idpRep.setDisplayName("Broker " + i);
+            idpRep.setProviderId("keycloak-oidc");
+            if (i >= 10)
+                idpRep.getConfig().put(OrganizationModel.BROKER_PUBLIC, Boolean.TRUE.toString());
+            testRealm().identityProviders().create(idpRep).close();
+            getCleanup().addCleanup(testRealm().identityProviders().get("alias")::remove);
+        }
+
+        String orgaId = testRealm().organizations().getAll().get(0).getId();
+        for (int i = 10; i < 20; i++) {
+            testRealm().organizations().get(orgaId).identityProviders().addIdentityProvider("idp-alias-" + i);
+        }
+
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            RealmModel realm = session.getContext().getRealm();
+            RealmCacheSession realmCache = (RealmCacheSession) session.getProvider(CacheRealmProvider.class);
+
+            // check all caches for login don't exist yet
+            for (FetchMode fetchMode : IdentityProviderStorageProvider.FetchMode.values()) {
+                String cachedKey = cacheKeyForLogin(realm, fetchMode);
+                IdentityProviderListQuery identityProviderListQuery = realmCache.getCache().get(cachedKey, IdentityProviderListQuery.class);
+                assertNull(identityProviderListQuery);
+            }
+
+            // perform some login IDP searches and ensure they are cached.
+            session.identityProviders().getForLogin(FetchMode.REALM_ONLY, null);
+            IdentityProviderListQuery identityProviderListQuery = realmCache.getCache().get(cacheKeyForLogin(realm, FetchMode.REALM_ONLY), IdentityProviderListQuery.class);
+            assertNotNull(identityProviderListQuery);
+            assertEquals(5, identityProviderListQuery.getIDPs("").size());
+
+            session.identityProviders().getForLogin(FetchMode.ORG_ONLY, orgaId);
+            identityProviderListQuery = realmCache.getCache().get(cacheKeyForLogin(realm, FetchMode.ORG_ONLY), IdentityProviderListQuery.class);
+            assertNotNull(identityProviderListQuery);
+            assertEquals(5, identityProviderListQuery.getIDPs(orgaId).size());
+
+            session.identityProviders().getForLogin(FetchMode.ALL, orgaId);
+            identityProviderListQuery = realmCache.getCache().get(cacheKeyForLogin(realm, FetchMode.ALL), IdentityProviderListQuery.class);
+            assertNotNull(identityProviderListQuery);
+            assertEquals(10, identityProviderListQuery.getIDPs(orgaId).size());
+        });
+
+        // 1- add/remove IDPs that are not available for login - none of these operations should invalidate the login caches.
+        IdentityProviderRepresentation idpRep = new IdentityProviderRepresentation();
+        idpRep.setAlias("idp-alias-" + 20);
+        idpRep.setEnabled(true);
+        idpRep.setHideOnLogin(true); // this will make the new IDP not available for login.
+        idpRep.setDisplayName("Broker " + 20);
+        idpRep.setProviderId("keycloak-oidc");
+        testRealm().identityProviders().create(idpRep).close();
+        getCleanup().addCleanup(testRealm().identityProviders().get("alias")::remove);
+
+        // remove one IDP that was not available for login.
+        testRealm().identityProviders().get("idp-alias-1").remove();
+
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            RealmModel realm = session.getContext().getRealm();
+            RealmCacheSession realmCache = (RealmCacheSession) session.getProvider(CacheRealmProvider.class);
+
+            // check all caches for login are still there.
+            for (FetchMode fetchMode : IdentityProviderStorageProvider.FetchMode.values()) {
+                String cachedKey = cacheKeyForLogin(realm, fetchMode);
+                IdentityProviderListQuery identityProviderListQuery = realmCache.getCache().get(cachedKey, IdentityProviderListQuery.class);
+                assertNotNull(identityProviderListQuery);
+            }
+        });
+
+        // 2- update a couple of idps (one not available for login, one available), but don't change their login-availability status
+        // none of these operations should invalidate the login caches.
+        idpRep = testRealm().identityProviders().get("idp-alias-20").toRepresentation();
+        idpRep.getConfig().put("somekey", "somevalue");
+        idpRep.setTrustEmail(true);
+        testRealm().identityProviders().get("idp-alias-20").update(idpRep); // should still be unavailable for login
+
+        idpRep = testRealm().identityProviders().get("idp-alias-0").toRepresentation();
+        idpRep.getConfig().put("somekey", "somevalue");
+        idpRep.setTrustEmail(true);
+        testRealm().identityProviders().get("idp-alias-0").update(idpRep); // should still be available for login
+
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            RealmModel realm = session.getContext().getRealm();
+            RealmCacheSession realmCache = (RealmCacheSession) session.getProvider(CacheRealmProvider.class);
+
+            // check all caches for login are still there.
+            for (FetchMode fetchMode : IdentityProviderStorageProvider.FetchMode.values()) {
+                String cachedKey = cacheKeyForLogin(realm, fetchMode);
+                IdentityProviderListQuery identityProviderListQuery = realmCache.getCache().get(cachedKey, IdentityProviderListQuery.class);
+                assertNotNull(identityProviderListQuery);
+            }
+        });
+
+        // 3- update an IDP, changing the availability for login - this should invalidate the caches.
+        idpRep = testRealm().identityProviders().get("idp-alias-20").toRepresentation();
+        idpRep.setHideOnLogin(false);
+        testRealm().identityProviders().get("idp-alias-20").update(idpRep);
+
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            RealmModel realm = session.getContext().getRealm();
+            RealmCacheSession realmCache = (RealmCacheSession) session.getProvider(CacheRealmProvider.class);
+
+            // check all caches have been cleared.
+            for (FetchMode fetchMode : IdentityProviderStorageProvider.FetchMode.values()) {
+                String cachedKey = cacheKeyForLogin(realm, fetchMode);
+                IdentityProviderListQuery identityProviderListQuery = realmCache.getCache().get(cachedKey, IdentityProviderListQuery.class);
+                assertNull(identityProviderListQuery);
+            }
+
+            // re-do searches to populate the caches again and check the updated results.
+            session.identityProviders().getForLogin(FetchMode.REALM_ONLY, null);
+            IdentityProviderListQuery identityProviderListQuery = realmCache.getCache().get(cacheKeyForLogin(realm, FetchMode.REALM_ONLY), IdentityProviderListQuery.class);
+            assertNotNull(identityProviderListQuery);
+            assertEquals(6, identityProviderListQuery.getIDPs("").size());
+
+            session.identityProviders().getForLogin(FetchMode.ORG_ONLY, orgaId);
+            identityProviderListQuery = realmCache.getCache().get(cacheKeyForLogin(realm, FetchMode.ORG_ONLY), IdentityProviderListQuery.class);
+            assertNotNull(identityProviderListQuery);
+            assertEquals(5, identityProviderListQuery.getIDPs(orgaId).size());
+
+            session.identityProviders().getForLogin(FetchMode.ALL, orgaId);
+            identityProviderListQuery = realmCache.getCache().get(cacheKeyForLogin(realm, FetchMode.ALL), IdentityProviderListQuery.class);
+            assertNotNull(identityProviderListQuery);
+            assertEquals(11, identityProviderListQuery.getIDPs(orgaId).size());
+
+        });
+
+        // 4- finally, change one of the realm-level login IDPs, linking it to an org - although it still qualifies for login, it is now
+        // linked to an org, which should invalidate all login caches.
+        idpRep = testRealm().identityProviders().get("idp-alias-20").toRepresentation();
+        idpRep.getConfig().put(OrganizationModel.BROKER_PUBLIC, Boolean.TRUE.toString());
+        testRealm().identityProviders().get("idp-alias-20").update(idpRep);
+        testRealm().organizations().get(orgaId).identityProviders().addIdentityProvider("idp-alias-20");
+
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            RealmModel realm = session.getContext().getRealm();
+            RealmCacheSession realmCache = (RealmCacheSession) session.getProvider(CacheRealmProvider.class);
+
+            // check all caches have been cleared.
+            for (FetchMode fetchMode : IdentityProviderStorageProvider.FetchMode.values()) {
+                String cachedKey = cacheKeyForLogin(realm, fetchMode);
+                IdentityProviderListQuery identityProviderListQuery = realmCache.getCache().get(cachedKey, IdentityProviderListQuery.class);
+                assertNull(identityProviderListQuery);
+            }
+
+            // re-do searches to populate the caches again and check the updated results.
+            session.identityProviders().getForLogin(FetchMode.REALM_ONLY, null);
+            IdentityProviderListQuery identityProviderListQuery = realmCache.getCache().get(cacheKeyForLogin(realm, FetchMode.REALM_ONLY), IdentityProviderListQuery.class);
+            assertNotNull(identityProviderListQuery);
+            assertEquals(5, identityProviderListQuery.getIDPs("").size());
+
+            session.identityProviders().getForLogin(FetchMode.ORG_ONLY, orgaId);
+            identityProviderListQuery = realmCache.getCache().get(cacheKeyForLogin(realm, FetchMode.ORG_ONLY), IdentityProviderListQuery.class);
+            assertNotNull(identityProviderListQuery);
+            assertEquals(6, identityProviderListQuery.getIDPs(orgaId).size());
+
+            session.identityProviders().getForLogin(FetchMode.ALL, orgaId);
+            identityProviderListQuery = realmCache.getCache().get(cacheKeyForLogin(realm, FetchMode.ALL), IdentityProviderListQuery.class);
+            assertNotNull(identityProviderListQuery);
+            assertEquals(11, identityProviderListQuery.getIDPs(orgaId).size());
+
         });
     }
 }


### PR DESCRIPTION
Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved caching and invalidation for identity providers available for login, enhancing performance and cache consistency for login-related queries.
* **Bug Fixes**
  * Ensured that only enabled identity providers are considered in organization-aware login flows.
* **Tests**
  * Added comprehensive tests to verify correct caching and invalidation behavior for login-eligible identity providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->