### PR TITLE
Fix concurrent group access to prevent NullPointerException

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/GroupAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/GroupAdapter.java
@@ -271,7 +271,8 @@ public class GroupAdapter implements GroupModel {
     @Override
     public Long getSubGroupsCount() {
         if (isUpdated()) return updated.getSubGroupsCount();
-        return getGroupModel().getSubGroupsCount();
+        GroupModel model = modelSupplier.get();
+        return model == null ? null : model.getSubGroupsCount();
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedGroup.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedGroup.java
@@ -58,6 +58,7 @@ public class CachedGroup extends AbstractRevisioned implements InRealm {
         this.type = group.getType();
     }
 
+    @Override
     public String getRealm() {
         return realm;
     }

--- a/services/src/main/java/org/keycloak/utils/GroupUtils.java
+++ b/services/src/main/java/org/keycloak/utils/GroupUtils.java
@@ -98,14 +98,4 @@ public class GroupUtils {
         rep.setAccess(groupsEvaluator.getAccess(groupTree));
         return rep;
     }
-
-    private static boolean groupMatchesSearchOrIsPathElement(GroupModel group, String search) {
-        if (StringUtil.isBlank(search)) {
-            return true;
-        }
-        if (group.getName().contains(search)) {
-            return true;
-        }
-        return group.getSubGroupsStream().findAny().isPresent();
-    }
 }


### PR DESCRIPTION
Test 10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify stability when reading and deleting multiple groups concurrently.

* **Bug Fixes**
  * Improved null safety when retrieving subgroup counts for groups.

* **Refactor**
  * Added an annotation to clarify method overriding in group-related code.
  * Removed an unused private method from group utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->